### PR TITLE
_requestHeaders to generate RETS-UA-Authorization hash regardless of password.

### DIFF
--- a/lib/rets.js
+++ b/lib/rets.js
@@ -984,12 +984,18 @@ Object.defineProperties( RETS.prototype, {
       this.set( 'settings.headers.User-Agent', this.get( 'settings.agent.user' ) );
       this.set( 'settings.headers.Accept', '*/*' );
 
-      if( this.get( 'settings.agent.user' ) && this.get( 'settings.agent.password' ) ) {
+      if( this.get( 'settings.agent.user' ) ) {
 
-        var ua_a1 = this.utility.md5([
-          this.get( 'settings.agent.user' ),
-          this.get( 'settings.agent.password' )
-        ].join( ':' ));
+        var aunth_credentials = [this.get( 'settings.agent.user' )];
+
+        var password = this.get( 'settings.agent.password' ) || this.get( 'settings.password' ) || this.get( 'settings.pass' ) || '';
+        aunth_credentials.push(password);
+
+        console.log();
+        console.log(aunth_credentials);
+        console.log();
+
+        var ua_a1 = this.utility.md5(aunth_credentials.join( ':' ));
 
         var ua_dig_resp = this.utility.md5([
           ua_a1.trim(),


### PR DESCRIPTION
In libRETS we are not being required to pass a password under auth.password but it goes through anyways generating the right hash. I believe it falls back into using the settings.password. This change made this code work for us. I could've simply passed the password twice but I think the spec defines this as optional. Keep in mind I'm only starting to get acquainted with the spec so I may be completely off. It does work for me though.
